### PR TITLE
Uptime counter

### DIFF
--- a/CAN Test Bench/Core/Src/imd.c
+++ b/CAN Test Bench/Core/Src/imd.c
@@ -54,7 +54,7 @@ uint8_t IMD_Serial_Number_Set = 0;
 
 
 int32_t IMD_Temperature;
-uint32_t IMD_UpTime;
+uint32_t IMD_Uptime;
 
 
 // If there is a hardware error, that one bit will be a 1 in the status bits -> read error flags

--- a/CAN Test Bench/Core/Src/imd.c
+++ b/CAN Test Bench/Core/Src/imd.c
@@ -54,6 +54,7 @@ uint8_t IMD_Serial_Number_Set = 0;
 
 
 int32_t IMD_Temperature;
+uint32_t IMD_UpTime;
 
 
 // If there is a hardware error, that one bit will be a 1 in the status bits -> read error flags
@@ -161,6 +162,7 @@ void IMD_Parse_Message(int DLC, uint8_t Data[]){
 
 		case Uptime_counter:
 			// call check uptime counter
+			IMD_Check_Uptime(Data);
 		break;
 
 
@@ -522,6 +524,7 @@ void IMD_Check_Serial_Number(uint8_t Data[]){
 
 void IMD_Check_Uptime(uint8_t Data[]){
 	// TODO
+	IMD_Uptime = (Data[4] << 24) | (Data[3] << 16) | (Data[2] << 8) | Data[1];
 }
 
 void IMD_Startup(){


### PR DESCRIPTION
Implemented the IMD_Check_Uptime function in the IMD executable file in the src directory. The function is very similar to the temperature check function as they are both 32-bit integers, the only difference is that the uptime counter is stored in an unsigned integer as it can not be negative. The Uptime_Counter value is already defined in the header file, in the case that the data matches up, the IMD_Check_Uptime function is called and the data array is passed in. The data array is bit-shifted to switch endianness and stored in the global IMD_Uptime variable.